### PR TITLE
Task recorder screenshot for chrome manifest v3

### DIFF
--- a/FMLab/TaskRecorderScreenshot/background.js
+++ b/FMLab/TaskRecorderScreenshot/background.js
@@ -1,8 +1,9 @@
-chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
-    if (request.name == 'screenshot') {
-        chrome.tabs.captureVisibleTab(null, null, function(dataUrl) {			
-            sendResponse({ screenshotUrl: dataUrl });
-        });
-    }
-    return true;
-});
+chrome.runtime.onMessage.addListener(
+    function(request, sender, sendResponse) {
+        if (request.name == 'screenshot') {
+            chrome.tabs.captureVisibleTab(null, null, function(dataUrl) {			
+                sendResponse({ screenshotUrl: dataUrl });
+            });
+        }
+        return true;
+    });

--- a/FMLab/TaskRecorderScreenshot/manifest.json
+++ b/FMLab/TaskRecorderScreenshot/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Dynamics 365 for Finance and Operations Task Recorder Screenshot Extension",
-  "version": "1.0.0.2",
+  "version": "1.0.0.3",
   "description": "Screenshot capture used for Dynamics 365 for Finance and Operations task recorder.",
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "content_scripts": [
 	  {
@@ -12,7 +12,9 @@
 	  }
   ],
   "permissions": [
-    "tabs", "<all_urls>"
+    "tabs",
+    "nativeMessaging"
   ],
-  "manifest_version": 2
+  "host_permissions": ["<all_urls>"],
+  "manifest_version": 3
 }

--- a/FMLab/TaskRecorderScreenshot/screenshot.js
+++ b/FMLab/TaskRecorderScreenshot/screenshot.js
@@ -1,5 +1,5 @@
 document.addEventListener("screenshot", function() {
-    chrome.extension.sendMessage({name: 'screenshot'}, function(response) {
+    chrome.runtime.sendMessage({name: 'screenshot'}, function(response) {
         var dataURL = response.screenshotUrl;
         var image = new Image();
 		


### PR DESCRIPTION
Updated task recorder screenshot extension to comply with chrome manifest v3:

- Changed to use background service worker
- Shifted "<all_urls>" permission to the new host permissions
- Updated manifest version to 3
- Updated background service from extension.onMessage to runtime.onMessage
- Updated screenshot script from extension.sendMessage to runtime.sendMessage