### PR TITLE
Update Chrome Extension manifest version to v3

### DIFF
--- a/FMLab/TaskRecorderScreenshot/background.js
+++ b/FMLab/TaskRecorderScreenshot/background.js
@@ -1,4 +1,4 @@
-chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (request.name == 'screenshot') {
         chrome.tabs.captureVisibleTab(null, null, function(dataUrl) {			
             sendResponse({ screenshotUrl: dataUrl });

--- a/FMLab/TaskRecorderScreenshot/manifest.json
+++ b/FMLab/TaskRecorderScreenshot/manifest.json
@@ -3,16 +3,23 @@
   "version": "1.0.0.2",
   "description": "Screenshot capture used for Dynamics 365 for Finance and Operations task recorder.",
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "content_scripts": [
-	  {
-		"matches": ["https://*.dynamics.com/*"],
-		"js": ["screenshot.js"]
-	  }
+    {
+      "matches": [
+        "https://*.dynamics.com/*"
+      ],
+      "js": [
+        "screenshot.js"
+      ]
+    }
   ],
   "permissions": [
-    "tabs", "<all_urls>"
+    "activeTab"
   ],
-  "manifest_version": 2
+  "host_permissions": [
+    "\u003Call_urls>"
+  ],
+  "manifest_version": 3
 }

--- a/FMLab/TaskRecorderScreenshot/screenshot.js
+++ b/FMLab/TaskRecorderScreenshot/screenshot.js
@@ -1,5 +1,5 @@
 document.addEventListener("screenshot", function() {
-    chrome.extension.sendMessage({name: 'screenshot'}, function(response) {
+    chrome.runtime.sendMessage({name: 'screenshot'}, function(response) {
         var dataURL = response.screenshotUrl;
         var image = new Image();
 		


### PR DESCRIPTION
Chrome Manifest V2 is deprecated. This update upgrades this to the latest supported extensions manifest version